### PR TITLE
Added support the c++-11 standard

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -54,8 +54,8 @@ macx {
 }
 
 HAVE_GCC {
-	QMAKE_CXXFLAGS_RELEASE += -s -O2 -Wno-non-virtual-dtor -Wno-long-long -pedantic -Wconversion
-	QMAKE_CXXFLAGS_DEBUG += -g3 -ggdb -O0 -Wno-non-virtual-dtor -Wno-long-long -pedantic -Wconversion
+    QMAKE_CXXFLAGS_RELEASE += -s -O2 -std=c++11 -Wno-non-virtual-dtor -Wno-long-long -pedantic -Wconversion
+    QMAKE_CXXFLAGS_DEBUG += -g3 -ggdb -O0 -std=c++11 -Wno-non-virtual-dtor -Wno-long-long -pedantic -Wconversion
 }
 
 ENABLE_CONSOLE_MSG {


### PR DESCRIPTION
This imposes restrictions on the use compilers:
  - GCC not less 4.7.x
  - MSVS not less MSVC2010